### PR TITLE
Fix demo in python 3

### DIFF
--- a/demo/settings.py
+++ b/demo/settings.py
@@ -106,3 +106,13 @@ STATIC_URL = '/static/'
 
 DJANGO_SCIM_NETLOC = 'localhost'
 
+SCIM_SERVICE_PROVIDER = {
+    'NETLOC': 'localhost',
+    'AUTHENTICATION_SCHEMES': [
+        {
+            'type': 'oauth2',
+            'name': 'OAuth 2',
+            'description': 'Oauth 2 implemented with bearer token',
+        },
+    ],
+}

--- a/demo/urls.py
+++ b/demo/urls.py
@@ -15,10 +15,9 @@ Including another URLconf
 from django.conf.urls import include, url
 from django.contrib import admin
 
+from django_scim.urls import urlpatterns as scim_urls
+
 urlpatterns = [
+    url(r'^scim/v2/', include('django_scim.urls', namespace='scim')),
     url(r'^admin/', include(admin.site.urls)),
 ]
-
-from django_scim.urls import urlpatterns as scim_urls
-urlpatterns += scim_urls
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Django>=1.5
-PlyPlus==0.5.6
-ply==3.4
+PlyPlus==0.7.5
+ply==3.10
 python-dateutil==2.1


### PR DESCRIPTION
Demo doesn't work in python 3 due to errors in both ply and plyplus. Update deps and update demo to match README.