### PR TITLE
Issue # 38: use attr_map of configured filter parser

### DIFF
--- a/src/django_scim/adapters.py
+++ b/src/django_scim/adapters.py
@@ -26,10 +26,11 @@ from scim2_filter_parser.attr_paths import AttrPath
 
 from . import constants
 from . import exceptions
-from . import filters
 from .utils import get_base_scim_location_getter
 from .utils import get_group_adapter
 from .utils import get_user_adapter
+from .utils import get_user_filter_parser
+from .utils import get_group_filter_parser
 
 
 class SCIMMixin(object):
@@ -296,7 +297,7 @@ class SCIMUser(SCIMMixin):
     url_name = 'scim:users'
     resource_type = 'User'
 
-    ATTR_MAP = filters.UserFilterQuery.attr_map
+    ATTR_MAP = get_user_filter_parser().attr_map
 
     @property
     def display_name(self):
@@ -509,7 +510,7 @@ class SCIMGroup(SCIMMixin):
     url_name = 'scim:groups'
     resource_type = 'Group'
 
-    ATTR_MAP = filters.GroupFilterQuery.attr_map
+    ATTR_MAP = get_group_filter_parser().attr_map
 
     @property
     def display_name(self):

--- a/tests/filters.py
+++ b/tests/filters.py
@@ -8,6 +8,11 @@ class UserFilterQuery(FilterQuery):
     model_getter = get_user_model
     attr_map = {
         ('userName', None, None): 'username',
+        ('name', 'familyName', None): 'last_name',
+        ('familyName', None, None): 'last_name',
+        ('name', 'givenName', None): 'first_name',
+        ('givenName', None, None): 'first_name',
+        ('active', None, None): 'is_active',
     }
 
 


### PR DESCRIPTION
Fixing https://github.com/15five/django-scim2/issues/38

* `attr_map` was hard coded and did not reflect the configured user/group filter parser. 
* fixed test as well