### PR TITLE
Consider nested filters in the extra_kwargs

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,10 @@
 CHANGE LOG
 ==========
 
+0.16.3
+------
+- Consider nested fields in extra_filter_kwargs and extra_exclude_kwargs
+
 0.16.2
 ------
 - Drop explicit support for Python 3.6


### PR DESCRIPTION
Allow nested filters to be applied to the search results. So if we get `{"account__admin__id": 123}, we compare the appropriate nested field. Right now, it understands `"account__admin__id"` to be a field name, which is incorrect.

Discussed in issue #47 and tested successfully in my local setup.