### PR TITLE
Fix tests in 0.16.3

### DIFF
--- a/src/django_scim/views.py
+++ b/src/django_scim/views.py
@@ -169,13 +169,13 @@ class FilterMixin(object):
         return self._build_response(request, qs, start, count)
 
     def _get_nested_field(self, obj, attr_key):
-        """Get a nested field for a given object, so 'a__b__c' returns obj.a.b.c"""
+        """Get a nested field for a given object, so 'a__b__c' returns a tuple with (obj.a.b.c, found)"""
         tokens = attr_key.split('__')
         for field_name in tokens:
             if not hasattr(obj, field_name):
-                return None
+                return None, False
             obj = getattr(obj, field_name)
-        return obj
+        return obj, True
 
     def _filter_raw_queryset_with_extra_filter_kwargs(self, qs, extra_filter_kwargs):
         obj_list = []
@@ -187,8 +187,8 @@ class FilterMixin(object):
                 else:
                     attr_val = [attr_val]
 
-                value = self._get_nested_field(obj, attr_key)
-                if not value or value not in attr_val:
+                value, found = self._get_nested_field(obj, attr_key)
+                if not found or value not in attr_val:
                     add_obj = False
                     break
 
@@ -207,8 +207,8 @@ class FilterMixin(object):
                 else:
                     attr_val = [attr_val]
 
-                value = self._get_nested_field(obj, attr_key)
-                if value and value in attr_val:
+                value, found = self._get_nested_field(obj, attr_key)
+                if found and value in attr_val:
                     add_obj = False
                     break
 


### PR DESCRIPTION
The tests at https://github.com/15five/django-scim2/runs/1306477812?check_suite_focus=true fail because we don't differentiate between:

- The field does not exist, and
- The field exists, but it's value is None

Here I make _get_nested_field return a (value, found) tuple that makes this distinction.