### PR TITLE
Add queryset post processor to GetView.get_many()

### DIFF
--- a/src/django_scim/settings.py
+++ b/src/django_scim/settings.py
@@ -32,6 +32,7 @@ DEFAULTS = {
     'GET_EXTRA_MODEL_FILTER_KWARGS_GETTER': 'django_scim.utils.default_get_extra_model_filter_kwargs_getter',
     'GET_EXTRA_MODEL_EXCLUDE_KWARGS_GETTER': 'django_scim.utils.default_get_extra_model_exclude_kwargs_getter',
     'GET_OBJECT_POST_PROCESSOR_GETTER': 'django_scim.utils.default_get_object_post_processor_getter',
+    'GET_QUERYSET_POST_PROCESSOR_GETTER': 'django_scim.utils.default_get_queryset_post_processor_getter',
     'SCHEMAS_GETTER': 'django_scim.schemas.default_schemas_getter',
     'DOCUMENTATION_URI': None,
     'SCHEME': 'https',
@@ -58,6 +59,7 @@ IMPORT_STRINGS = (
     'GET_EXTRA_MODEL_FILTER_KWARGS_GETTER',
     'GET_EXTRA_MODEL_EXCLUDE_KWARGS_GETTER',
     'GET_OBJECT_POST_PROCESSOR_GETTER',
+    'GET_QUERYSET_POST_PROCESSOR_GETTER',
     'SCHEMAS_GETTER',
 )
 

--- a/src/django_scim/utils.py
+++ b/src/django_scim/utils.py
@@ -86,6 +86,14 @@ def get_object_post_processor_getter(model):
     return scim_settings.GET_OBJECT_POST_PROCESSOR_GETTER(model)
 
 
+def get_queryset_post_processor_getter(model):
+    """
+    Return a function that will, when called, returns the
+    get_queryset_post_processor function.
+    """
+    return scim_settings.GET_QUERYSET_POST_PROCESSOR_GETTER(model)
+
+
 def default_base_scim_location_getter(request=None, *args, **kwargs):
     """
     Return the default location of the app implementing the SCIM api.
@@ -162,6 +170,28 @@ def default_get_object_post_processor_getter(model):
         return obj
 
     return get_object_post_processor
+
+
+def default_get_queryset_post_processor_getter(model):
+    """
+    Return a **method** that can be used to perform any post processing
+    on a queryset about to be returned from GetView.get_many().
+
+    :param model:
+    """
+    def get_queryset_post_processor(request, qs, *args, **kwargs):
+        """
+        Perform any post processing on queryset to be returned from GetView.get_many().
+
+        :param request:
+        :param qs:
+        :param args:
+        :param kwargs:
+        :rtype: Django Queryset
+        """
+        return qs
+
+    return get_queryset_post_processor
 
 
 def clean_structure_of_passwords(obj):

--- a/src/django_scim/views.py
+++ b/src/django_scim/views.py
@@ -24,6 +24,7 @@ from .utils import (
     get_group_filter_parser,
     get_group_model,
     get_object_post_processor_getter,
+    get_queryset_post_processor_getter,
     get_service_provider_config_model,
     get_user_adapter,
     get_user_filter_parser,
@@ -58,6 +59,10 @@ class SCIMView(View):
     @property
     def get_object_post_processor(self):
         return get_object_post_processor_getter(self.model_cls)
+
+    @property
+    def get_queryset_post_processor(self):
+        return get_queryset_post_processor_getter(self.model_cls)
 
     @property
     def scim_adapter(self):
@@ -297,7 +302,9 @@ class GetView(object):
             **extra_filter_kwargs
         ).exclude(
             **extra_exclude_kwargs
-        ).order_by(self.lookup_field)
+        )
+        qs = self.get_queryset_post_processor(request, qs)
+        qs = qs.order_by(self.lookup_field)
         return self._build_response(request, qs, *self._page(request))
 
 


### PR DESCRIPTION
I needed to be able to modify the queryset returned from GetView.get_many() in ways filter/exclude kwargs didn't allow. I took inspiration from the object post processor used in SCIMView.get_object() and implemented a queryset post processor that allows you to modify the queryset after filter/exlclude kwargs are applied, but before the queryset is ordered and returned.

There may be a use-case where we'd also want to use this on the queryset in get_object(), but I personally didn't need it and the object post processor can be used on the object anyway. I would be happy to implement it that way if it is desired.