### PR TITLE
Update build-system from poetry to poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,5 +86,5 @@ commands =
 """
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This is more efficient for downstream users because they’ll no longer have to pull in all of Poetry and its dependencies to build django-scim2.

https://python-poetry.org/blog/announcing-poetry-1.1.0/#standalone-build-backend