### PR TITLE
Change scim2-filter-parser pin to lower bound

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -375,7 +375,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6"
-content-hash = "efe17918926c5376ea3edbc42ed41ab128f1d0155792422debfedda0457e55e2"
+content-hash = "de668a3482aab8add99dbfb2a3b2bae7012f4f2c0e59c6cc68a5941c76e42863"
 
 [metadata.files]
 asgiref = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.6"
-scim2-filter-parser = "0.3.5"
+scim2-filter-parser = ">=0.3.5"
 Django = ">=2.0"
 python-dateutil = ">=2.7.3"
 

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     install_requires=[
         'Django>=2.2',
         'python-dateutil>=2.7.3',
-        'scim2-filter-parser==0.3.5',
+        'scim2-filter-parser>=0.3.5',
     ],
     tests_require=[
         'mock',


### PR DESCRIPTION
There have now been several scim2-filter-parser releases without a corresponding django-scim2 release. We should allow users to benefit from those fixes.

(We could alternatively specify `~=0.3.5` or `>=0.3.5, <0.4` or `>=0.3.5, <1` if you’re more comfortable with that.)