### PR TITLE
Add Custom Authenticate Verification

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,9 @@ Make sure to place this middleware after authentication middleware as this
 middleware simply checks `request.user.is_anonymous()` to determine if the SCIM
 request should be allowed or denied.
 
+If you have specific authentication needs, look into overriding the default "is
+authenticated predicate" (ie. see `GET_IS_AUTHENTICATED_PREDICATE` for details).
+
 Add the necessary url patterns to your root urls.py file. Please note that the
 namespace is mandatory and must be named `scim`::
 
@@ -98,7 +101,12 @@ https://github.com/15five/django-scim2/actions
 Tests are typically run locally with `tox` (https://tox.wiki/). Tox will test
 all supported versions of Python and Django.
 
-To run the test suite with the current version of Python, run:
+```
+tox
+```
+
+To run the test suite with a single version of Python (the version you created
+the virtualenv with), run:
 
 ```
 poetry run pytest tests/
@@ -113,8 +121,7 @@ Coverage
 https://codecov.io/gh/15five/django-scim2/
 
 ```
-poetry run coverage run -m pytest
-poetry run coverage report -m
+tox -e coverage
 ```
 
 License

--- a/src/django_scim/middleware.py
+++ b/src/django_scim/middleware.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 
 from . import constants
 from .settings import scim_settings
-from .utils import get_loggable_body
+from .utils import get_is_authenticated_predicate, get_loggable_body
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +49,7 @@ class SCIMAuthCheckMiddleware(object):
         # If we've just passed through the auth middleware and there is no user
         # associated with the request we can assume permission
         # was denied and return a 401.
-        if not hasattr(request, 'user') or request.user.is_anonymous:
+        if not hasattr(request, 'user') or not get_is_authenticated_predicate()(request.user):
             if request.path.startswith(self.reverse_url):
                 response = HttpResponse(status=401)
                 response['WWW-Authenticate'] = scim_settings.WWW_AUTHENTICATE_HEADER

--- a/src/django_scim/settings.py
+++ b/src/django_scim/settings.py
@@ -33,6 +33,7 @@ DEFAULTS = {
     'GET_EXTRA_MODEL_EXCLUDE_KWARGS_GETTER': 'django_scim.utils.default_get_extra_model_exclude_kwargs_getter',
     'GET_OBJECT_POST_PROCESSOR_GETTER': 'django_scim.utils.default_get_object_post_processor_getter',
     'GET_QUERYSET_POST_PROCESSOR_GETTER': 'django_scim.utils.default_get_queryset_post_processor_getter',
+    'GET_IS_AUTHENTICATED_PREDICATE': 'django_scim.utils.default_is_authenticated_predicate',
     'SCHEMAS_GETTER': 'django_scim.schemas.default_schemas_getter',
     'DOCUMENTATION_URI': None,
     'SCHEME': 'https',
@@ -61,6 +62,7 @@ IMPORT_STRINGS = (
     'GET_EXTRA_MODEL_EXCLUDE_KWARGS_GETTER',
     'GET_OBJECT_POST_PROCESSOR_GETTER',
     'GET_QUERYSET_POST_PROCESSOR_GETTER',
+    'GET_IS_AUTHENTICATED_PREDICATE',
     'SCHEMAS_GETTER',
 )
 

--- a/src/django_scim/utils.py
+++ b/src/django_scim/utils.py
@@ -94,6 +94,18 @@ def get_queryset_post_processor_getter(model):
     return scim_settings.GET_QUERYSET_POST_PROCESSOR_GETTER(model)
 
 
+def get_is_authenticated_predicate():
+    """
+    Return function that will perform customized authn/z actions during
+    `.dispatch` method processing. This defaults to Django's `user.is_authenticated`.
+    """
+    return scim_settings.GET_IS_AUTHENTICATED_PREDICATE
+
+
+def default_is_authenticated_predicate(user):
+    return user.is_authenticated
+
+
 def default_base_scim_location_getter(request=None, *args, **kwargs):
     """
     Return the default location of the app implementing the SCIM api.


### PR DESCRIPTION
This commit adds a new SCIM setting named
`GET_IS_AUTHENTICATED_PREDICATE`. This setting points to a function that
determines if the user is authenticated or not. This function can be
overridden by supplying one's own authentication predicate.

Closes https://github.com/15five/django-scim2/issues/78. 

Blocked by https://github.com/15five/django-scim2/pull/81