### PR TITLE
Apply SCIMAuthCheckMiddleware directly to SCIMView.dispatch

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,15 @@
 CHANGE LOG
 ==========
 
+0.18.0
+------
+
+- `SCIMAuthCheckMiddleware` is now applied as a decorator directly to
+  the SCIM view functions.  Therefore, it no longer needs to be
+  configured as a middleware in Django's `MIDDLEWARE` setting.  If you
+  want to customize it, you can do so using the
+  `AUTH_CHECK_MIDDLEWARE` key of the `SCIM_SERVICE_PROVIDER` setting.
+
 0.17.3
 ------
 

--- a/README.rst
+++ b/README.rst
@@ -23,19 +23,13 @@ Then add the ``django_scim`` app to ``INSTALLED_APPS`` in your Django's settings
         'django_scim',
     )
 
-Add the appropriate middleware to authorize or deny the SCIM calls::
-
-    MIDDLEWARE = (
-        ...
-        'django_scim.middleware.SCIMAuthCheckMiddleware',
-        ...
-    )
-Make sure to place this middleware after authentication middleware as this
-middleware simply checks `request.user.is_anonymous()` to determine if the SCIM
+By default, ``request.user.is_anonymous()`` is checked to determine if the SCIM
 request should be allowed or denied.
 
 If you have specific authentication needs, look into overriding the default "is
-authenticated predicate" (ie. see `GET_IS_AUTHENTICATED_PREDICATE` for details).
+authenticated predicate" (i.e. see ``GET_IS_AUTHENTICATED_PREDICATE`` for
+details) or subclassing the middleware that performs the check
+(``AUTH_CHECK_MIDDLEWARE``).
 
 Add the necessary url patterns to your root urls.py file. Please note that the
 namespace is mandatory and must be named `scim`::

--- a/demo/root/settings.py
+++ b/demo/root/settings.py
@@ -52,7 +52,6 @@ MIDDLEWARE = (
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'oauth2_provider.middleware.OAuth2TokenMiddleware',
-    'app.middleware.CustomSCIMAuthCheckMiddleware',
 )
 
 AUTHENTICATION_BACKENDS = [
@@ -229,6 +228,7 @@ SCIM_SERVICE_PROVIDER = {
     'SCHEME': 'https',
     # use default value, this will be overridden by value returned by BASE_LOCATION_GETTER
     'NETLOC': 'localhost',
+    'AUTH_CHECK_MIDDLEWARE': 'app.middleware.CustomSCIMAuthCheckMiddleware',
     'AUTHENTICATION_SCHEMES': [
         {
             'type': 'oauth2',

--- a/src/django_scim/middleware.py
+++ b/src/django_scim/middleware.py
@@ -21,12 +21,12 @@ class SCIMAuthCheckMiddleware(object):
         # One-time configuration and initialization per server start.
         self.get_response = get_response
 
-    def __call__(self, request):
+    def __call__(self, request, *args, **kwargs):
         response = None
         if hasattr(self, 'process_request'):
             response = self.process_request(request)
         if not response:
-            response = self.get_response(request)
+            response = self.get_response(request, *args, **kwargs)
         if hasattr(self, 'process_response'):
             response = self.process_response(request, response)
         return response

--- a/src/django_scim/settings.py
+++ b/src/django_scim/settings.py
@@ -34,6 +34,7 @@ DEFAULTS = {
     'GET_OBJECT_POST_PROCESSOR_GETTER': 'django_scim.utils.default_get_object_post_processor_getter',
     'GET_QUERYSET_POST_PROCESSOR_GETTER': 'django_scim.utils.default_get_queryset_post_processor_getter',
     'GET_IS_AUTHENTICATED_PREDICATE': 'django_scim.utils.default_is_authenticated_predicate',
+    'AUTH_CHECK_MIDDLEWARE': 'django_scim.middleware.SCIMAuthCheckMiddleware',
     'SCHEMAS_GETTER': 'django_scim.schemas.default_schemas_getter',
     'DOCUMENTATION_URI': None,
     'SCHEME': 'https',
@@ -63,6 +64,7 @@ IMPORT_STRINGS = (
     'GET_OBJECT_POST_PROCESSOR_GETTER',
     'GET_QUERYSET_POST_PROCESSOR_GETTER',
     'GET_IS_AUTHENTICATED_PREDICATE',
+    'AUTH_CHECK_MIDDLEWARE',
     'SCHEMAS_GETTER',
 )
 

--- a/src/django_scim/views.py
+++ b/src/django_scim/views.py
@@ -3,8 +3,7 @@ import logging
 from urllib.parse import urljoin
 
 from django import db
-from django.contrib.auth import REDIRECT_FIELD_NAME, get_user_model
-from django.contrib.auth.decorators import user_passes_test
+from django.contrib.auth import get_user_model
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 from django.db import transaction
 from django.http import HttpResponse
@@ -24,7 +23,6 @@ from .utils import (
     get_group_adapter,
     get_group_filter_parser,
     get_group_model,
-    get_is_authenticated_predicate,
     get_object_post_processor_getter,
     get_queryset_post_processor_getter,
     get_service_provider_config_model,
@@ -33,27 +31,6 @@ from .utils import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-def login_required(
-    function=None,
-    redirect_field_name=REDIRECT_FIELD_NAME,
-    login_url=None,
-):
-    """
-    Decorator for views that checks that the user is logged in, redirecting to
-    the log-in page if necessary.
-
-    This function was pulled almost directly from Django's implementation.
-    """
-    actual_decorator = user_passes_test(
-        get_is_authenticated_predicate(),  # <- Only line that differs from Django's implementation.
-        login_url=login_url,
-        redirect_field_name=redirect_field_name,
-    )
-    if function:
-        return actual_decorator(function)
-    return actual_decorator
 
 
 class SCIMView(View):
@@ -126,7 +103,7 @@ class SCIMView(View):
             raise exceptions.BadRequestError(msg)
 
     @method_decorator(csrf_exempt)
-    @method_decorator(login_required)
+    @method_decorator(scim_settings.AUTH_CHECK_MIDDLEWARE)
     def dispatch(self, request, *args, **kwargs):
         if not self.implemented:
             return self.status_501(request, *args, **kwargs)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -31,7 +31,6 @@ MIDDLEWARE = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
-    'django_scim.middleware.SCIMAuthCheckMiddleware',
 )
 
 ROOT_URLCONF = 'tests.urls'


### PR DESCRIPTION
This way, the user no longer needs to install our middleware in their project settings; this simplifies configuration and avoids a performance penalty for all non-SCIM requests.

Additionally, since `SCIMView` now has a guarantee that `SCIMAuthCheckMiddleware` is being used (unless the new `AUTH_CHECK_MIDDLEWARE` setting is explicitly overridden), it no longer needs to perform its own redundant version of the check.

With the redundant check removed, we could go further and remove the `GET_IS_AUTHENTICATED_PREDICATE` setting, since the same effect can be achieved by setting the `AUTH_CHECK_MIDDLEWARE` setting to a custom subclass of `SCIMAuthCheckMiddleware`.

@logston What do you think about this strategy?