### PR TITLE
Make get_user_model configurable

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,12 @@
 CHANGE LOG
 ==========
 
+0.18.1
+------
+
+- Add ability to override the Django User model used to look up a given User
+  object.
+
 0.18.0
 ------
 

--- a/demo/app/adapters.py
+++ b/demo/app/adapters.py
@@ -1,21 +1,15 @@
 import copy
 import logging
-import re
 
-import django
 from django import core
-from django.conf import settings
-from django.contrib.auth import get_user_model
-from django.db import IntegrityError, transaction
-from django.db.models import Prefetch
-from django.utils.functional import cached_property
+from django.db import transaction
 
 from app import constants
-from app.models import Group, User
+from app.models import Group
 from django_scim import exceptions as scim_exceptions
-from django_scim.adapters import SCIMGroup, SCIMUser
-from django_scim.constants import SchemaURI
-from django_scim.utils import get_group_adapter, get_group_model
+from django_scim.adapters import SCIMUser
+from django_scim.utils import get_group_adapter
+
 
 logger = logging.getLogger(__name__)
 

--- a/src/django_scim/adapters.py
+++ b/src/django_scim/adapters.py
@@ -20,7 +20,6 @@ from typing import Optional, Union
 from urllib.parse import urljoin
 
 from django import core
-from django.contrib.auth import get_user_model
 from django.urls import reverse
 from scim2_filter_parser.attr_paths import AttrPath
 
@@ -31,6 +30,7 @@ from .utils import (
     get_group_filter_parser,
     get_user_adapter,
     get_user_filter_parser,
+    get_user_model,
 )
 
 

--- a/src/django_scim/filters.py
+++ b/src/django_scim/filters.py
@@ -1,10 +1,9 @@
 """
 Transform filter query into QuerySet
 """
-from django.contrib.auth import get_user_model
 from scim2_filter_parser.queries.sql import SQLQuery
 
-from .utils import get_group_model
+from .utils import get_group_model, get_user_model
 
 
 class FilterQuery:

--- a/src/django_scim/settings.py
+++ b/src/django_scim/settings.py
@@ -22,6 +22,7 @@ from django.conf import settings
 USER_SETTINGS = getattr(settings, 'SCIM_SERVICE_PROVIDER', None)
 
 DEFAULTS = {
+    'USER_MODEL_GETTER': 'django.contrib.auth.get_user_model',
     'USER_ADAPTER': 'django_scim.adapters.SCIMUser',
     'GROUP_MODEL': 'django.contrib.auth.models.Group',
     'GROUP_ADAPTER': 'django_scim.adapters.SCIMGroup',
@@ -52,6 +53,7 @@ MANDATORY = (
 
 # List of settings that may be in string import notation.
 IMPORT_STRINGS = (
+    'USER_MODEL_GETTER',
     'USER_ADAPTER',
     'GROUP_MODEL',
     'GROUP_ADAPTER',

--- a/src/django_scim/utils.py
+++ b/src/django_scim/utils.py
@@ -4,6 +4,13 @@ from urllib.parse import urlunparse
 from .settings import scim_settings
 
 
+def get_user_model():
+    """
+    Return the user model.
+    """
+    return scim_settings.USER_MODEL_GETTER()
+
+
 def get_user_adapter():
     """
     Return the user model adapter.

--- a/src/django_scim/views.py
+++ b/src/django_scim/views.py
@@ -3,7 +3,6 @@ import logging
 from urllib.parse import urljoin
 
 from django import db
-from django.contrib.auth import get_user_model
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 from django.db import transaction
 from django.http import HttpResponse
@@ -28,6 +27,7 @@ from .utils import (
     get_service_provider_config_model,
     get_user_adapter,
     get_user_filter_parser,
+    get_user_model,
 )
 
 logger = logging.getLogger(__name__)

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,15 +1,11 @@
 from unittest.mock import patch
 
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import AbstractUser
-from django.db import connection, models
 from django.test import RequestFactory, TestCase, override_settings
 from scim2_filter_parser.attr_paths import AttrPath
 
 from django_scim import constants
-from django_scim import models as scim_models
 from django_scim.adapters import SCIMMixin
-from django_scim.utils import get_group_adapter, get_user_adapter
+from django_scim.utils import get_group_adapter, get_user_adapter, get_user_model
 
 from tests.models import get_group_model
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,7 +1,7 @@
-from django.contrib.auth import get_user_model
 from django.test import TestCase
 
 from tests.filters import UserFilterQuery
+from django_scim.utils import get_user_model
 
 
 class Users(TestCase):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,12 +1,8 @@
 import django
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import AbstractUser
-from django.db import connection, models
 from django.test import TestCase, override_settings
 
 from django_scim import constants
-from django_scim import models as scim_models
-from django_scim.utils import get_service_provider_config_model
+from django_scim.utils import get_service_provider_config_model, get_user_model
 
 # Force loading of test.models so its models are registered with Django and
 # testing framework.

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -3,16 +3,11 @@ import json
 from unittest import mock, skip
 from urllib.parse import urljoin
 
-from django.contrib.auth import get_user_model
 from django.contrib.auth.hashers import make_password
-from django.contrib.auth.models import AbstractUser
-from django.db import connection, models
 from django.test import Client, RequestFactory, TestCase, override_settings
 from django.urls import reverse
-import pytest
 
 from django_scim import constants
-from django_scim import models as scim_models
 from django_scim import views
 from django_scim.schemas import ALL as ALL_SCHEMAS
 from django_scim.utils import (
@@ -20,6 +15,7 @@ from django_scim.utils import (
     get_group_adapter,
     get_service_provider_config_model,
     get_user_adapter,
+    get_user_model,
 )
 
 from tests.models import get_group_model


### PR DESCRIPTION
This commit replaces Django's implementation of get_user_model with a configuration hook that allows developers to use their own User model.

Closes #100 