### PR TITLE
Allow sorting via get_queryset_post_processor 

### DIFF
--- a/src/django_scim/views.py
+++ b/src/django_scim/views.py
@@ -312,8 +312,8 @@ class GetView(object):
         ).exclude(
             **extra_exclude_kwargs
         )
-        qs = self.get_queryset_post_processor(request, qs)
         qs = qs.order_by(self.lookup_field)
+        qs = self.get_queryset_post_processor(request, qs)
         return self._build_response(request, qs, *self._page(request))
 
 


### PR DESCRIPTION
This commit updates the `get_many` method to allow sorting by the
`get_queryset_post_processor` to persist in the response.

Closes https://github.com/15five/django-scim2/issues/107.