### PR TITLE
Cleanup unused mention of Python 3.7 in tox file

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ envlist =
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310
@@ -19,7 +18,6 @@ setenv =
     PYTHONDONTWRITEBYTECODE=1
     DJANGO_SETTINGS_MODULE=tests.settings
 basepython =
-    py37: python3.7
     py38: python3.8
     py39: python3.9
     py310: python3.10


### PR DESCRIPTION
The tox.ini file still mentions Python 3.7 in a couple of places, but it's no longer used since https://github.com/15five/django-scim2/pull/98