### PR TITLE
Add support up to Django 5.1 and Python 3.13

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-django>=2.2.13,<5.0.0
+django>=2.2.13,<5.2
 django-scim2  # not pinning, should always work with latest release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,8 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Internet",
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -33,8 +33,12 @@ basepython =
     py313: python3.13
     .package: python3
 deps =
-    django32: Django>=3.2,<4
-    django40: Django>=4.0
+    django32: Django>=3.2,<4.0
+    django40: Django>=4.0,<4.1
+    django41: Django>=4.1,<4.2
+    django42: Django>=4.2,<5.0
+    django50: Django>=5.0,<5.1
+    django51: Django>=5.1,<5.2
 allowlist_externals = poetry
 commands =
     poetry install -v

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,10 @@
 isolated_build = True
 envlist =
     py{38,39,310,311}-django{32}
-    py{38,39,310,311}-django{40}
+    py{38,39,310,311}-django{40,41}
+    py{38,39,310,311,312}-django{42}
+    py{310,311,312}-django{50}
+    py{310,311,312,313}-django{51}
     flake8
     coverage
 
@@ -13,6 +16,8 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
+    3.13: py313
 
 [testenv]
 setenv =
@@ -24,6 +29,8 @@ basepython =
     py39: python3.9
     py310: python3.10
     py311: python3.11
+    py312: python3.12
+    py313: python3.13
     .package: python3
 deps =
     django32: Django>=3.2,<4


### PR DESCRIPTION
Following [Django's Python version support](https://docs.djangoproject.com/en/5.1/faq/install/#what-python-version-can-i-use-with-django).

- [x] Add Python 3.12, 3.13 and Django 4.1-5.1 to the CI
- [x] Update classifiers
- [x] Fix anything that breaks