### PR TITLE
Upgrade docs to Sphinx 8

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,11 +77,9 @@ Development
 -----------
 
 This project uses Poetry to manage dependencies, etc. Thus to install the
-necessary tools when developing, run:
+necessary tools when developing, run::
 
-```
-poetry install
-```
+    poetry install
 
 Tests
 -----
@@ -92,20 +90,14 @@ Tests
 https://github.com/15five/django-scim2/actions
 
 Tests are typically run locally with `tox` (https://tox.wiki/). Tox will test
-all supported versions of Python and Django.
+all supported versions of Python and Django::
 
-```
-tox
-```
+    tox
 
 To run the test suite with a single version of Python (the version you created
-the virtualenv with), run:
+the virtualenv with), run::
 
-
-```
-poetry run pytest tests/
-```
-
+    poetry run pytest tests/
 
 Coverage
 --------
@@ -115,9 +107,10 @@ Coverage
 
 https://codecov.io/gh/15five/django-scim2/
 
-```
-tox -e coverage
-```
+To run tests with coverage::
+
+    tox -e coverage
+
 
 License
 -------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ import sys
 
 sys.path.insert(0, os.path.abspath('..'))
 
-os.environ['DJANGO_SETTINGS_MODULE'] = 'test_settings'
+os.environ['DJANGO_SETTINGS_MODULE'] = 'tests.settings'
 import django;django.setup()
 
 import django_scim  # isort:skip
@@ -165,4 +165,4 @@ texinfo_documents = [
 ]
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {"python": ('https://docs.python.org/',  None)}

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,4 @@
 django>=2.2.13,<5.0.0
 django-scim2  # not pinning, should always work with latest release
+Sphinx>=8,<9
+sphinx-rtd-theme


### PR DESCRIPTION
I noticed that the documentation seems out of date, with [no builds in the past 2 years](https://app.readthedocs.org/projects/django-scim2/builds/). I suspect the GitHub webhooks are no longer firing, I vaguely recall that RTD changed their GH integration a while back, you might have to [visit this page](https://app.readthedocs.org/dashboard/django-scim2/integrations/) and setup the integration again.

Also, you may want to enable a preview of the docs on PRs to have a failed status when this happens next. This can be done [here](https://app.readthedocs.org/dashboard/django-scim2/edit/), by ticking this checkbox:

![image](https://github.com/user-attachments/assets/7a2c1f74-741b-49af-bf65-9e286550e535)


