### PR TITLE
Version Bump -> 0.21.0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,18 @@
 CHANGE LOG
 ==========
 
+0.21.0
+------
+
+- Fix ``itemsPerPage`` in SCIM list responses to report the number of
+  resources actually returned rather than the requested ``count``
+  (SCIM RFC 7644 section 3.4.2). (#208, #210)
+- Drop support for EOL Python 3.8 and Django < 4.2.
+- Add support for Python 3.12 / 3.13 and Django 5.0 / 5.1.
+- Update dependencies (Django 4.2.30, scim2-filter-parser, pytest,
+  pytest-django, tox, coverage, flake8, mock).
+- Demo app and documentation fixes (Sphinx 8, Read the Docs config).
+
 0.19.1
 ------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-scim2"
-version = "0.19.1"
+version = "0.21.0"
 description = "A partial implementation of the SCIM 2.0 provider specification for use with Django."
 license = "MIT"
 authors = ["Paul Logston <paul@15five.com>"]


### PR DESCRIPTION
Cuts the first release since `0.19.1`, shipping the accumulated `main` backlog.

## Version

`0.19.1` → `0.21.0` (minor). Skips `0.20.0` to avoid the pre-existing stray `0.20.0` git tag (which points 67 commits back with `pyproject` still at `0.19.1` and was never published to PyPI).

## Included changes

- Fix `itemsPerPage` in SCIM list responses to report the number of resources actually returned rather than the requested `count`, per SCIM RFC 7644 §3.4.2 (#208, #210).
- Drop support for EOL Python 3.8 and Django < 4.2.
- Add support for Python 3.12 / 3.13 and Django 5.0 / 5.1.
- Dependency updates (Django 4.2.30, scim2-filter-parser, pytest, pytest-django, tox, coverage, flake8, mock).
- Demo app and documentation fixes (Sphinx 8, Read the Docs config).

## Post-merge (manual — no CI publish job)

- `poetry build && poetry publish`
- Push a `0.21.0` git tag; ideally back-fill the missing `0.19.1` tag.