### PR TITLE
Raise SCIM error on IntegrityError in PutView (#209)

### DIFF
--- a/src/django_scim/views.py
+++ b/src/django_scim/views.py
@@ -369,7 +369,12 @@ class PutView(object):
 
         scim_obj.validate_dict(body)
         scim_obj.from_dict(body)
-        scim_obj.save()
+        try:
+            scim_obj.save()
+        except db.utils.IntegrityError as e:
+            # Cast error to a SCIM IntegrityError to use the status
+            # attribute on the SCIM IntegrityError.
+            raise exceptions.IntegrityError(str(e))
 
         content = json.dumps(scim_obj.to_dict())
         response = HttpResponse(content=content,

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -716,6 +716,32 @@ class UserTestCase(LoginMixin, TestCase):
         ford = get_user_adapter()(ford, self.request)
         self.assertEqual(result, ford.to_dict())
 
+    def test_put_integrity_error_returns_scim_error(self):
+        # Regression test for #209: a database IntegrityError raised while saving in
+        # PutView must surface as a SCIM error response (409 Conflict) rather than an
+        # unhandled 500, matching PostView's behaviour.
+        import django.db.utils
+
+        ford = get_user_model().objects.create(
+            first_name='Robert',
+            last_name='Ford',
+            username='rford',
+            email='rford@ww.com',
+        )
+
+        url = reverse('scim:users', kwargs={'uuid': ford.id})
+        data = get_user_adapter()(ford, self.request).to_dict()
+        data['userName'] = 'updatedrford'
+        body = json.dumps(data)
+
+        with mock.patch(
+            'django_scim.adapters.SCIMUser.save',
+            side_effect=django.db.utils.IntegrityError('duplicate key'),
+        ):
+            resp = self.client.put(url, body, content_type=constants.SCIM_CONTENT_TYPE)
+
+        self.assertEqual(resp.status_code, 409, resp.content.decode())
+
     def test_put_invalid_active_value(self):
         ford = get_user_model().objects.create(
             first_name='Robert',


### PR DESCRIPTION
Fixes #209.

`PostView` wraps `scim_obj.save()` in a `try/except` that casts a database `IntegrityError` to a SCIM `IntegrityError` (HTTP 409), so a constraint violation returns a well-formed SCIM error response. `PutView.put()` called `scim_obj.save()` unguarded, so the same failure surfaced as an unhandled HTTP 500.

This applies the exact same handler to `PutView`, giving consistent SCIM error responses across create and replace.

Added `test_put_integrity_error_returns_scim_error`, which patches the adapter's `save()` to raise `django.db.utils.IntegrityError` and asserts the response is `409` rather than `500`. It fails on `main` and passes with this change; the full suite still passes (78 passed).

*Disclosure: written with AI assistance; reviewed and tested before submitting.*
