### PR TITLE
DEV-4644 release/0.22.0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,18 @@
 CHANGE LOG
 ==========
 
+0.22.0
+------
+
+- Add support for Python 3.14. (#219)
+- Raise a SCIM error on ``IntegrityError`` in ``PutView`` rather than
+  returning a 500. (#209, #214)
+- Bump minimum supported Python version to 3.10. (#217)
+- Run CI on pull requests. (#216)
+- Move coverage reporting to coveralls.io. (#206)
+- Update dependencies (django-oauth-toolkit 3.4.0, pytest 9.0.3,
+  Sphinx 8.1.3). (#211, #212, #215, #218)
+
 0.21.0
 ------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-scim2"
-version = "0.21.0"
+version = "0.22.0"
 description = "A partial implementation of the SCIM 2.0 provider specification for use with Django."
 license = "MIT"
 authors = ["Paul Logston <paul@15five.com>"]


### PR DESCRIPTION
## Version Bump -> 0.22.0

Release PR bumping `pyproject.toml` and `CHANGES.txt` for the 0.22.0 release.

### Changes since 0.21.0
- Add support for Python 3.14. (#219)
- Raise a SCIM error on `IntegrityError` in `PutView` rather than returning a 500. (#209, #214)
- Bump minimum supported Python version to 3.10. (#217)
- Run CI on pull requests. (#216)
- Move coverage reporting to coveralls.io. (#206)
- Update dependencies (django-oauth-toolkit 3.4.0, pytest 9.0.3, Sphinx 8.1.3). (#211, #212, #215, #218)

### Post-merge (manual, by a maintainer)
```
git tag 0.22.0 && git push --tags
poetry build
poetry publish   # PyPI token from Vault
```