### PR TITLE
DEV-4644 Add Django 6.0 support

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,11 @@
 CHANGE LOG
 ==========
 
+Unreleased
+----------
+
+- Add support for Django 6.0.
+
 0.22.0
 ------
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -668,4 +668,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "b90de8ec2b92dc058bc0d5a075f4ffe26f1622978ddd8074599322263a114c30"
+content-hash = "1f0abc3072f508893495ffbb81b4fa445527b0b7b942f00438ace34667342b60"

--- a/poetry.lock
+++ b/poetry.lock
@@ -667,4 +667,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "caf9544df1da8e897dbc43d9cc331f878bcb5d591019e26cf45c1af1eadd498d"
+content-hash = "43081bb68c81785471124762e622b875a0a3ba7e4a955a9e8dac20ca21fcc44a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ packages = [
 [tool.poetry.dependencies]
 python = ">=3.10"
 scim2-filter-parser = ">=0.5.0"
-django = ">=4.2.30,<5.3"
+django = ">=4.2.30,<6.1"
 pygments = "^2.20.0"
 
 [tool.poetry.dev-dependencies]

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ isolated_build = True
 envlist =
     py{311,312}-django{42}
     py{313,314}-django{52}
+    py{312,313,314}-django{60}
     flake8
     coverage
 
@@ -26,6 +27,7 @@ basepython =
 deps =
     django42: Django>=4.2,<5.0
     django52: Django>=5.2.8,<5.3
+    django60: Django>=6.0,<6.1
     pytest>=5.4.0
     pytest-django>=4.11.1,<5.0
 allowlist_externals = poetry


### PR DESCRIPTION
## Summary

Adds support for Django 6.0 (released Dec 3, 2025).

- Widen the Django dependency constraint in `pyproject.toml` from `<5.3` to `<6.1`.
- Add `py{312,313,314}-django60` test environments to `tox.ini` (Django 6.0 requires Python 3.12+).
- Regenerate `poetry.lock`.
- Add a changelog entry.

## Notes

Django 6.0 supports Python 3.12, 3.13, and 3.14, so the new tox factors only pair `django60` with those interpreters. Python 3.10/3.11 remain covered by the Django 4.2 / 5.2 environments.

## Testing

The full test suite passes against Django 6.0.8 on Python 3.12:

```
78 passed, 7 skipped
```