### PR TITLE
DEV-4644 Drop Django 4.2 support

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,7 @@ Unreleased
 ----------
 
 - Add support for Django 6.0.
+- Drop support for Django 4.2 (end of extended support April 2026).
 
 0.22.0
 ------

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-django>=4.2,<5.2
+django>=5.2.8,<6.1
 django-scim2  # not pinning, should always work with latest release
 Sphinx>=8.1.3,<9
 sphinx-rtd-theme

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,18 +2,22 @@
 
 [[package]]
 name = "asgiref"
-version = "3.6.0"
+version = "3.12.1"
 description = "ASGI specs, helper code, and adapters"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "asgiref-3.6.0-py3-none-any.whl", hash = "sha256:71e68008da809b957b7ee4b43dbccff33d1b23519fb8344e33f049897077afac"},
-    {file = "asgiref-3.6.0.tar.gz", hash = "sha256:9567dfe7bd8d3c8c892227827c41cce860b368104c3431da67a0c5a65a949506"},
+    {file = "asgiref-3.12.1-py3-none-any.whl", hash = "sha256:fe386d1c2bff7259ea95929266d12a8cf9a8b5a1c2598402967d8792e7a7c094"},
+    {file = "asgiref-3.12.1.tar.gz", hash = "sha256:59dcb51c272ad209d59bed5708a64a333083e86017d7fcdd67498eeab7784340"},
 ]
 
+[package.dependencies]
+typing_extensions = {version = ">=4", markers = "python_version < \"3.11\""}
+
 [package.extras]
-tests = ["mypy (>=0.800)", "pytest", "pytest-asyncio"]
+mypy = ["mypy (>=1.14.0)"]
+tests = ["pytest", "pytest-asyncio"]
 
 [[package]]
 name = "cachetools"
@@ -173,18 +177,18 @@ files = [
 
 [[package]]
 name = "django"
-version = "4.2.30"
+version = "5.2.17"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "django-4.2.30-py3-none-any.whl", hash = "sha256:4d07aaf1c62f9984842b67c2874ebbf7056a17be253860299b93ae1881faad65"},
-    {file = "django-4.2.30.tar.gz", hash = "sha256:4ebc7a434e3819db6cf4b399fb5b3f536310a30e8486f08b66886840be84b37c"},
+    {file = "django-5.2.17-py3-none-any.whl", hash = "sha256:f04fb3b36ee119e1af4fa1d397d5fd6cf12700f49321e84d4f4c642c5b1973db"},
+    {file = "django-5.2.17.tar.gz", hash = "sha256:9d4d93be539a18ab80d058eb515900e10951e04c537c5a6b394fc49528d3251f"},
 ]
 
 [package.dependencies]
-asgiref = ">=3.6.0,<4"
+asgiref = ">=3.8.1"
 sqlparse = ">=0.3.1"
 tzdata = {version = "*", markers = "sys_platform == \"win32\""}
 
@@ -648,7 +652,7 @@ version = "4.16.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 markers = "python_version == \"3.10\""
 files = [
     {file = "typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8"},
@@ -690,4 +694,4 @@ typing-extensions = {version = ">=4.13.2", markers = "python_version < \"3.11\""
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "d108010bfdccc3e0bf2d3f2c6dd60274b11b5f0492d9a101a944a5aa0ad87c9d"
+content-hash = "61be7c765dcfb0cf9ef82366e49f12c8e4fb1a0469c1159e6d09501aac9de3ca"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,18 +2,22 @@
 
 [[package]]
 name = "asgiref"
-version = "3.6.0"
+version = "3.12.1"
 description = "ASGI specs, helper code, and adapters"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "asgiref-3.6.0-py3-none-any.whl", hash = "sha256:71e68008da809b957b7ee4b43dbccff33d1b23519fb8344e33f049897077afac"},
-    {file = "asgiref-3.6.0.tar.gz", hash = "sha256:9567dfe7bd8d3c8c892227827c41cce860b368104c3431da67a0c5a65a949506"},
+    {file = "asgiref-3.12.1-py3-none-any.whl", hash = "sha256:fe386d1c2bff7259ea95929266d12a8cf9a8b5a1c2598402967d8792e7a7c094"},
+    {file = "asgiref-3.12.1.tar.gz", hash = "sha256:59dcb51c272ad209d59bed5708a64a333083e86017d7fcdd67498eeab7784340"},
 ]
 
+[package.dependencies]
+typing_extensions = {version = ">=4", markers = "python_version < \"3.11\""}
+
 [package.extras]
-tests = ["mypy (>=0.800)", "pytest", "pytest-asyncio"]
+mypy = ["mypy (>=1.14.0)"]
+tests = ["pytest", "pytest-asyncio"]
 
 [[package]]
 name = "cachetools"
@@ -185,18 +189,18 @@ files = [
 
 [[package]]
 name = "django"
-version = "4.2.30"
+version = "5.2.17"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "django-4.2.30-py3-none-any.whl", hash = "sha256:4d07aaf1c62f9984842b67c2874ebbf7056a17be253860299b93ae1881faad65"},
-    {file = "django-4.2.30.tar.gz", hash = "sha256:4ebc7a434e3819db6cf4b399fb5b3f536310a30e8486f08b66886840be84b37c"},
+    {file = "django-5.2.17-py3-none-any.whl", hash = "sha256:f04fb3b36ee119e1af4fa1d397d5fd6cf12700f49321e84d4f4c642c5b1973db"},
+    {file = "django-5.2.17.tar.gz", hash = "sha256:9d4d93be539a18ab80d058eb515900e10951e04c537c5a6b394fc49528d3251f"},
 ]
 
 [package.dependencies]
-asgiref = ">=3.6.0,<4"
+asgiref = ">=3.8.1"
 sqlparse = ">=0.3.1"
 tzdata = {version = "*", markers = "sys_platform == \"win32\""}
 
@@ -623,7 +627,7 @@ version = "4.14.1"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 markers = "python_version == \"3.10\""
 files = [
     {file = "typing_extensions-4.14.1-py3-none-any.whl", hash = "sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76"},
@@ -668,4 +672,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "1f0abc3072f508893495ffbb81b4fa445527b0b7b942f00438ace34667342b60"
+content-hash = "c4869e2a249a1f9ed77a6607f500432dd3a093e43dcca5ef2ccd0ffc2b864d89"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ packages = [
 [tool.poetry.dependencies]
 python = ">=3.10"
 scim2-filter-parser = ">=0.5.0"
-django = ">=4.2.30,<6.1"
+django = ">=5.2.8,<6.1"
 pygments = "^2.20.0"
 
 [tool.poetry.dev-dependencies]

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
 isolated_build = True
 envlist =
-    py{311,312}-django{42}
-    py{313,314}-django{52}
+    py{311,312,313,314}-django{52}
     py{312,313,314}-django{60}
     flake8
     coverage
@@ -25,7 +24,6 @@ basepython =
     py314: python3.14
     .package: python3
 deps =
-    django42: Django>=4.2,<5.0
     django52: Django>=5.2.8,<5.3
     django60: Django>=6.0,<6.1
     pytest>=5.4.0


### PR DESCRIPTION
Stacked on #221 (Django 6.0 support). **Merge #221 first**, or rebase this onto `main` after #221 lands.

## Summary

Drops support for Django 4.2, which reached end of extended support on **April 7, 2026**. Supported Django is now **5.2 and 6.0**.

- `pyproject.toml`: raise the Django floor from `>=4.2.30` to `>=5.2.8` (keep upper bound `<6.1`).
- `tox.ini`: remove the `django42` environments and dep; Python 3.11/3.12 now test against Django 5.2. Matrix is `py{311,312,313,314}-django52` + `py{312,313,314}-django60`.
- `docs/requirements.txt`: bump the stale `django>=4.2,<5.2` pin (which excluded every supported version) to `>=5.2.8,<6.1`.
- Regenerate `poetry.lock`.
- Changelog entry.

## On "drop EOL Python versions"

No currently-supported Python version is EOL yet, so there is nothing to drop:

| Python | EOL | Status |
|--------|-----|--------|
| 3.10 | ~Oct 2026 | not yet EOL (security-only) |
| 3.11 | ~Oct 2027 | supported |
| 3.12 | ~Oct 2028 | supported |
| 3.13 | ~Oct 2029 | supported |
| 3.14 | ~Oct 2030 | supported |

Python 3.9 was already dropped in a prior release, and 3.10 remains in security support until ~October 2026. Python support is therefore unchanged (floor stays 3.10). A follow-up can drop 3.10 once it actually reaches EOL.

## Testing

Full suite passes against the new floor, Django 5.2.17 on Python 3.12: `78 passed, 7 skipped`.