### PR TITLE
DEV-4644 Version Bump -> 0.23.0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,8 +4,11 @@ CHANGE LOG
 Unreleased
 ----------
 
-- Add support for Django 6.0.
-- Drop support for Django 4.2 (end of extended support April 2026).
+0.23.0
+------
+
+- Add support for Django 6.0. (#221)
+- Drop support for Django 4.2 (end of extended support April 2026). (#222)
 
 0.22.0
 ------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-scim2"
-version = "0.22.0"
+version = "0.23.0"
 description = "A partial implementation of the SCIM 2.0 provider specification for use with Django."
 license = "MIT"
 authors = ["Paul Logston <paul@15five.com>"]


### PR DESCRIPTION
Release 0.23.0.

## Changes since 0.22.0

- Add support for Django 6.0. (#221)
- Drop support for Django 4.2 (end of extended support April 2026). (#222)

After merge, a maintainer runs the manual publish steps: tag `0.23.0`, `poetry build`, `poetry publish`.